### PR TITLE
Make banyak/m3 nullable and normalize decimals

### DIFF
--- a/app/Filament/Pages/JurnalUmum.php
+++ b/app/Filament/Pages/JurnalUmum.php
@@ -34,7 +34,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
     public $tgl, $jurnal, $no_dokumen, $no_akun, $nama_akun, $nama, $keterangan;
     public $harga = '';
     public $total = '';
-    public $banyak = '1';
+    public $banyak = '';
     public $mm = '';
     public $m3 = '';
     public $hit_kbk = '';
@@ -214,88 +214,12 @@ class JurnalUmum extends Page implements HasActions, HasForms
 
     public function updatedHitKbk($value): void
     {
-        if ($value === 'b') {
-            $this->banyak = '1';
-            $this->m3 = '';
-        } elseif ($value === 'm') {
-            $this->banyak = '';
-            $this->m3 = '';
-        } else {
-            $this->banyak = '';
-            $this->m3 = '';
+        if (blank($value)) {
             $this->total = $this->harga;
         }
     }
 
-    public function updatedHarga($value): void
-    {
-        $h = blank($value) ? 0.0 : (float) $value;
 
-        if ($this->hit_kbk === 'b') {
-            $b = blank($this->banyak) ? 0.0 : (float) $this->banyak;
-            if ($b > 0) {
-                $this->total = (string) ($b * $h);
-            }
-        } elseif ($this->hit_kbk === 'm') {
-            $m = blank($this->m3) ? 0.0 : (float) $this->m3;
-            if ($m > 0) {
-                $this->total = (string) ($m * $h);
-            }
-        } else {
-            $this->total = $value;
-        }
-    }
-
-    public function updatedTotal($value): void
-    {
-        $t = blank($value) ? 0.0 : (float) $value;
-
-        if ($this->hit_kbk === 'b') {
-            $b = blank($this->banyak) ? 0.0 : (float) $this->banyak;
-            if ($b > 0) {
-                $this->harga = (string) ($t / $b);
-            }
-        } elseif ($this->hit_kbk === 'm') {
-            $m = blank($this->m3) ? 0.0 : (float) $this->m3;
-            if ($m > 0) {
-                $this->harga = (string) ($t / $m);
-            }
-        } else {
-            $this->harga = $value;
-        }
-    }
-
-    public function updatedBanyak($value): void
-    {
-        $b = blank($value) ? 0.0 : (float) $value;
-
-        if ($this->hit_kbk === 'b' && $b > 0) {
-            $t = blank($this->total) ? 0.0 : (float) $this->total;
-            $h = blank($this->harga) ? 0.0 : (float) $this->harga;
-
-            if ($t > 0) {
-                $this->harga = (string) ($t / $b);
-            } elseif ($h > 0) {
-                $this->total = (string) ($b * $h);
-            }
-        }
-    }
-
-    public function updatedM3($value): void
-    {
-        $m = blank($value) ? 0.0 : (float) $value;
-
-        if ($this->hit_kbk === 'm' && $m > 0) {
-            $t = blank($this->total) ? 0.0 : (float) $this->total;
-            $h = blank($this->harga) ? 0.0 : (float) $this->harga;
-
-            if ($t > 0) {
-                $this->harga = (string) ($t / $m);
-            } elseif ($h > 0) {
-                $this->total = (string) ($m * $h);
-            }
-        }
-    }
 
     public function updated($propertyName): void
     {
@@ -325,15 +249,8 @@ class JurnalUmum extends Page implements HasActions, HasForms
         // ── Hitung total setelah harga dipastikan valid ──────────
         $harga  = (float) $this->harga;
 
-        $banyak = null;
-        if ($this->hit_kbk === 'b') {
-            $banyak = blank($this->banyak) ? null : (float) $this->banyak;
-        }
-
-        $m3 = null;
-        if ($this->hit_kbk === 'm') {
-            $m3 = blank($this->m3) ? null : (float) $this->m3;
-        }
+        $banyak = blank($this->banyak) ? null : (float) $this->banyak;
+        $m3     = blank($this->m3) ? null : (float) str_replace(',', '.', $this->m3);
 
         $total = match ($this->hit_kbk) {
             'b'     => ($banyak ?? 0.0) * $harga,
@@ -382,7 +299,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
             'total',
             'hit_kbk'
         ]);
-        $this->banyak = '1';
+        $this->banyak = '';
 
         $this->dispatch('toast', type: 'info', title: 'Item Ditambahkan', msg: 'Item berhasil masuk ke draft.');
 
@@ -446,7 +363,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
         $this->wasBalanced = false;
         $this->reset(['no_akun', 'nama_akun', 'nama', 'keterangan', 'mm', 'm3']);
         $this->harga   = '';
-        $this->banyak  = 1;
+        $this->banyak  = '';
         $this->map     = 'd';
         $this->hit_kbk = '';
         $this->total = '';
@@ -469,7 +386,6 @@ class JurnalUmum extends Page implements HasActions, HasForms
         $this->banyak  = '';
         $this->map     = 'd';
         $this->hit_kbk = '';
-        $this->banyak  = 1;
         $this->m3      = '';
         $this->total = '';
         $this->persistDraftState();
@@ -608,13 +524,13 @@ class JurnalUmum extends Page implements HasActions, HasForms
                 $data['nama']       = $data['nama'] ?? '';
 
                 $harga  = blank($data['harga'] ?? null) ? 0.0 : (float) $data['harga'];
-                $banyak = blank($data['banyak'] ?? null) ? 0.0 : (float) $data['banyak'];
-                $m3     = blank($data['m3'] ?? null) ? 0.0 : (float) $data['m3'];
+                $banyak = blank($data['banyak'] ?? null) ? null : (float) $data['banyak'];
+                $m3     = blank($data['m3'] ?? null) ? null : (float) str_replace(',', '.', $data['m3']);
                 $hit_kbk = $data['hit_kbk'];
 
                 $total = match ($hit_kbk) {
-                    'b' => $banyak * $harga,
-                    'm' => $m3 * $harga,
+                    'b' => ($banyak ?? 0.0) * $harga,
+                    'm' => ($m3 ?? 0.0) * $harga,
                     default => $harga,
                 };
 
@@ -627,6 +543,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
                 }
 
                 $data['banyak'] = $banyak;
+                $data['m3']     = $m3;
                 $data['harga']  = $harga;
                 $data['total']  = $total;
 
@@ -666,13 +583,13 @@ class JurnalUmum extends Page implements HasActions, HasForms
                 $data['nama']       = $data['nama'] ?? '';
 
                 $harga  = blank($data['harga'] ?? null) ? 0.0 : (float) $data['harga'];
-                $banyak = blank($data['banyak'] ?? null) ? 0.0 : (float) $data['banyak'];
-                $m3     = blank($data['m3'] ?? null) ? 0.0 : (float) $data['m3'];
+                $banyak = blank($data['banyak'] ?? null) ? null : (float) $data['banyak'];
+                $m3     = blank($data['m3'] ?? null) ? null : (float) str_replace(',', '.', $data['m3']);
                 $hit_kbk = $data['hit_kbk'];
 
                 $total = match ($hit_kbk) {
-                    'b' => $banyak * $harga,
-                    'm' => $m3 * $harga,
+                    'b' => ($banyak ?? 0.0) * $harga,
+                    'm' => ($m3 ?? 0.0) * $harga,
                     default => $harga,
                 };
 
@@ -685,6 +602,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
                 }
 
                 $data['banyak'] = $banyak;
+                $data['m3']     = $m3;
                 $data['harga']  = $harga;
                 $data['total']  = $total;
 
@@ -712,7 +630,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
             });
     }
 
-    protected function validateJurnalData(string $hit_kbk, float &$harga, float &$total, float &$banyak, float $m3): array
+    protected function validateJurnalData(string $hit_kbk, float &$harga, float &$total, ?float &$banyak, ?float &$m3): array
     {
         $errors = [];
         if (blank($hit_kbk)) {
@@ -721,7 +639,12 @@ class JurnalUmum extends Page implements HasActions, HasForms
             } elseif ($total < 0.01 && $harga >= 0.01) {
                 $total = $harga;
             }
-            $banyak = 1.0;
+            if ($banyak === '' || $banyak === null) {
+                $banyak = null;
+            }
+            if ($m3 === '' || $m3 === null) {
+                $m3 = null;
+            }
             if ($harga < 0.01) {
                 $errors[] = 'Harga atau Total wajib diisi (minimal Rp 1).';
             }
@@ -736,7 +659,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
                 $errors[] = 'Total wajib diisi (minimal Rp 1).';
             }
             if ($hit_kbk === 'b') {
-                if ($banyak < 0.0001) {
+                if ($banyak === null || $banyak < 0.0001) {
                     $errors[] = 'Kuantitas (Banyak) harus diisi dan lebih dari 0.';
                 } else {
                     $expected = $banyak * $harga;
@@ -745,7 +668,7 @@ class JurnalUmum extends Page implements HasActions, HasForms
                     }
                 }
             } elseif ($hit_kbk === 'm') {
-                if ($m3 < 0.000001) {
+                if ($m3 === null || $m3 < 0.000001) {
                     $errors[] = 'Kubikasi (M3) harus diisi dan lebih dari 0.';
                 } else {
                     $expected = $m3 * $harga;

--- a/resources/views/filament/pages/jurnal-umum.blade.php
+++ b/resources/views/filament/pages/jurnal-umum.blade.php
@@ -740,8 +740,8 @@
                         <input type="text" inputmode="decimal" x-model="m3" placeholder="0.000000"
                             @blur="
                                 if (m3 !== '') {
-                                    let num = parseFloat(m3);
-                                    m3 = isNaN(num) ? '' : num.toFixed(6);
+                                    let num = parseFloat(m3.toString().replace(',', '.'));
+                                    m3 = isNaN(num) ? '' : parseFloat(num.toFixed(6)).toString().replace('.', ',');
                                     $wire.set('m3', m3);
                                 }
                             "
@@ -753,7 +753,7 @@
                                 let t = parseFloat(parseInputID(total_display));
                                 if (!isNaN(h) && h > 0 && !isNaN(t)) {
                                     let res = t / h;
-                                    m3 = res.toFixed(6);
+                                    m3 = parseFloat(res.toFixed(6)).toString().replace('.', ',');
                                     $wire.set('m3', m3);
                                 } else {
                                     window.showToast('error', 'Gagal', 'Harga dan Total harus diisi & lebih dari 0.');
@@ -807,7 +807,7 @@
                                 let divisor = 0;
                                 let label = '';
                                 if (hit_kbk === 'm') {
-                                    divisor = parseFloat(m3);
+                                    divisor = parseFloat(m3.toString().replace(',', '.'));
                                     label = 'Kubikasi';
                                 } else {
                                     divisor = parseFloat(parseInputID(banyak_display));
@@ -869,7 +869,7 @@
                                 let multiplier = 0;
                                 let label = '';
                                 if (hit_kbk === 'm') {
-                                    multiplier = parseFloat(m3);
+                                    multiplier = parseFloat(m3.toString().replace(',', '.'));
                                     label = 'Kubikasi';
                                 } else {
                                     multiplier = parseFloat(parseInputID(banyak_display));
@@ -928,6 +928,8 @@
                                 let rawTotal  = parseInputID(total_display);
                                 await $wire.set('harga',  rawHarga  === '' ? '' : rawHarga);
                                 await $wire.set('banyak', rawBanyak === '' ? '' : rawBanyak);
+                                let rawM3 = m3.toString().replace(',', '.');
+                                    await $wire.set('m3',     rawM3 === '' ? '' : rawM3);
                                 await $wire.set('total',  rawTotal  === '' ? '' : rawTotal);
                                 await $wire.call('addItem');
                             }()
@@ -1026,7 +1028,7 @@
                                 <div class="text-right shrink-0">
                                     <span class="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums"
                                         x-text="(row.m3 !== null && row.m3 !== undefined && row.m3 !== '' && parseFloat(row.m3) > 0)
-                                    ? parseFloat(row.m3).toFixed(6)
+                                    ? parseFloat(parseFloat(row.m3).toFixed(6)).toString().replace('.', ',')
                                     : '-'">
                                     </span>
                                 </div>
@@ -1517,12 +1519,14 @@
                                     {{ $hj->hit_kbk ?? '-' }}
                                 </td>
                                 
-                                <td class="px-4 py-4 text-right font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap">{{ $hj->banyak == intval($hj->banyak)
-                                ? number_format($hj->banyak, 0, ',', '.')
-                                : number_format($hj->banyak, 2, ',', '.') }}</td>
+                                <td class="px-4 py-4 text-right font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                                    {{ ($hj->banyak !== null && $hj->banyak !== '')
+                                    ? ($hj->banyak == intval($hj->banyak) ? number_format($hj->banyak, 0, ',', '.') : number_format($hj->banyak, 2, ',', '.'))
+                                    : '-' }}
+                                </td>
                                 
                                 <td class="px-4 py-4 text-right font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap">
-                                    {{ (float)$hj->m3 > 0 ? number_format((float)$hj->m3, 4, ',', '.') : '-' }}
+                                    {{ (float)$hj->m3 > 0 ? rtrim(rtrim(number_format((float)$hj->m3, 6, ',', '.'), '0'), ',') : '-' }}
                                 </td>
 
                                 <td class="px-4 py-4 text-right text-gray-400 dark:text-gray-500 font-mono whitespace-nowrap">{{ $hj->harga == intval($hj->harga)


### PR DESCRIPTION
Change default banyak from '1' to empty and treat banyak/m3 as nullable values across the page logic. Remove/streamline multiple per-field update handlers and centralize calculation logic to account for nullable banyak/m3, preventing invalid implicit defaults. Normalize decimal input/outputs by converting comma/period in Blade JS and when setting Livewire properties, and ensure m3 is stored with a dot as decimal separator. Update validation to require kuantitas/kubikasi only when relevant and to validate expected total/harga calculations. Adjust table and input formatting to display proper precision and locale-aware separators.